### PR TITLE
Added PdfTeX support via iftex

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -5,7 +5,7 @@
 % arara: lualatex: { shell: yes }
 
 \documentclass[ngerman]{ttlab-qualify}
-% mögliche Optionen:
+%%% mögliche Optionen:
 % - ngerman
 % - english
 % - minted

--- a/ttlab-qualify.cls
+++ b/ttlab-qualify.cls
@@ -97,7 +97,7 @@
 \ifbool{nolibertine}{}{
   \ifPDFTeX
     \RequirePackage{libertine} % serif and sans-serif fonts
-    \RequirePackage[scaled=0.8]{DejaVuSansMono} % monospace font
+    \RequirePackage[scaled=0.785]{DejaVuSansMono} % monospace font
   \else
     \setromanfont[Ligatures=TeX]{Linux Libertine O} % serif font
     \setsansfont[Ligatures=TeX]{Linux Biolinum O} % sans-serif font

--- a/ttlab-qualify.cls
+++ b/ttlab-qualify.cls
@@ -83,11 +83,26 @@
 \LoadClass[titlepage=on, fontsize=12pt, bibliography=totoc, headings=small, captions=tableheading]{scrreprt}
 
 %%% Font:
-\ifbool{nolibertine}{}{
+\RequirePackage{iftex}
+\ifPDFTeX
+  \RequirePackage[T1]{fontenc}
+  \RequirePackage[utf8]{inputenc}
+\else
+  \ifXeTeX
+    \ClassWarning{ttlab-qualify}{Use LuaLaTeX instead of XeLaTeX}
+  \fi
   \RequirePackage{fontspec}
-  \setromanfont[Mapping=tex-text]{Linux Libertine O} % Serifenschrift
-  \setsansfont[Mapping=tex-text]{Linux Biolinum O} % serifenlose Schrift
-  \setmonofont[Scale=MatchLowercase]{DejaVu Sans Mono}%
+\fi
+
+\ifbool{nolibertine}{}{
+  \ifPDFTeX
+    \RequirePackage{libertine} % serif and sans-serif fonts
+    \RequirePackage[scaled=0.8]{DejaVuSansMono} % monospace font
+  \else
+    \setromanfont[Ligatures=TeX]{Linux Libertine O} % serif font
+    \setsansfont[Ligatures=TeX]{Linux Biolinum O} % sans-serif font
+    \setmonofont[Scale=MatchLowercase]{DejaVu Sans Mono} % monospace font
+  \fi
 }
 
 %%% Load some useful packages:

--- a/ttlab-qualify.cls
+++ b/ttlab-qualify.cls
@@ -72,13 +72,15 @@
 }
 
 \DeclareOption*{%
-  \PackageWarning{ttlab-qualify}{Unknown option '\CurrentOption'}%
+  \PassOptionsToClass{\CurrentOption}{scrreprt}
 }
 
 \ExecuteOptions{ngerman}
+\ExecuteOptions{pagesize=auto}
+\ExecuteOptions{paper=a4}
 \ProcessOptions*\relax
 
-\LoadClass[pagesize=auto, paper=a4, titlepage=on, fontsize=12pt, bibliography=totoc, headings=small, captions=tableheading]{scrreprt}
+\LoadClass[titlepage=on, fontsize=12pt, bibliography=totoc, headings=small, captions=tableheading]{scrreprt}
 
 %%% Font:
 \ifbool{nolibertine}{}{


### PR DESCRIPTION
Automatically detects `PdfTeX` and `LuaTeX` and changes package imports and font setup accordingly. If `XeTeX` is used, a warning is omitted that advises the use of `LuaTeX`,
as `XeTeX` has not been updated since at least 2020, compiles generally slower and offers no improvements over `LuaTeX`.

Also moved `pagesize=auto` and `paper=a4` to global options by passing unknown class options to `scrreprt` (this fixes two warnings).